### PR TITLE
fix: handle empty page when no reconciliation entries found

### DIFF
--- a/langs/en_US/camt053readerandlink.lang
+++ b/langs/en_US/camt053readerandlink.lang
@@ -38,4 +38,5 @@ ConcilationsConfirmed = Conciliations confirmed
 CheckNewConciliations = Check new conciliations
 ViewBankStatement = View bank statement
 AllEntriesReconciled = All entries are already reconciled
+NoEntriesToReconcile = No entries found to reconcile
 BasedOnPreviousMonthIfNotFilled = Based on the previous month of the file extraction date if not filled

--- a/langs/fr_FR/camt053readerandlink.lang
+++ b/langs/fr_FR/camt053readerandlink.lang
@@ -40,4 +40,5 @@ ConcilationsConfirmed = Rapprochements confirmés
 CheckNewConciliations = Vérifier les nouveaux rapprochements
 ViewBankStatement = Voir le relevé bancaire
 AllEntriesReconciled = Toutes les écritures sont déjà rapprochées
+NoEntriesToReconcile = Aucune écriture trouvée à rapprocher
 BasedOnPreviousMonthIfNotFilled = Basé sur le mois précédent de la date d'extraction du fichier si non rempli

--- a/submit.php
+++ b/submit.php
@@ -131,6 +131,9 @@ if ($action == 'upload') {
 		if (!empty($file_json)) {
 			// Parse from previously uploaded JSON
 			$structure = json_decode(urldecode($file_json), true);
+			if (!is_array($structure)) {
+				throw new Exception('Error decoding JSON structure');
+			}
 			if (!$fileProcessor->parseStructure($structure)) {
 				throw new Exception($fileProcessor->getError() ?? 'Error parsing JSON structure');
 			}
@@ -223,6 +226,9 @@ if ($action == 'upload') {
 	} catch (Exception $e) {
 		dol_syslog('CAMT053: Error processing file - ' . $e->getMessage(), LOG_ERR);
 		$processError = $e->getMessage();
+	} catch (TypeError $e) {
+		dol_syslog('CAMT053: Type error processing file - ' . $e->getMessage(), LOG_ERR);
+		$processError = $e->getMessage();
 	}
 }
 
@@ -256,6 +262,9 @@ if (!empty($processError)) {
 }
 
 // Display results if we have data
+if (empty($banks) && empty($processError)) {
+	print '<div class="opacitymedium">'.$langs->trans('NoEntriesToReconcile').'</div>';
+}
 if (!empty($banks)) {
 	print '<form id="form" name="form" action="'.dol_buildpath('/custom/camt053readerandlink/confirm.php', 1).'" method="post">';
 


### PR DESCRIPTION
Add null check before parseStructure() to prevent TypeError on invalid JSON, catch TypeError in addition to Exception, and display a message when no entries are found instead of showing a blank page.