### PR TITLE
fix: bank statement reconciliation errors and file archiving

### DIFF
--- a/confirm.php
+++ b/confirm.php
@@ -126,9 +126,10 @@ $reconciler = new BankEntryReconciler($db, $user);
 // Counters and errors to give visible feedback instead of failing silently
 $reconcileSuccess = 0;
 $reconcileErrors = array();
-// Real bank account id(s) of the reconciled lines (the upload form has no account selector,
-// so bank_account_id is empty: we must derive the account from the reconciled lines)
-$reconciledAccountIds = array();
+// Real bank account id(s) of the submitted linked lines (the upload form has no account selector,
+// so bank_account_id is empty: we must derive the account from the linked lines). Captured right
+// after fetch() so it is known even if the reconciliation itself later fails.
+$linkedAccountIds = array();
 
 // An empty statement reference makes update_conciliation() fail when BANK_STATEMENT_REGEX_RULE is set
 if (empty($date_concil)) {
@@ -154,6 +155,12 @@ try {
 			continue;
 		}
 
+		// Remember the real bank account now, even if the reconciliation below fails, so the
+		// statement file is still archived under the correct account (never under account 0)
+		if (!empty($obj->fk_account)) {
+			$linkedAccountIds[(int) $obj->fk_account] = (int) $obj->fk_account;
+		}
+
 		// Reconcile the entry
 		$obj->num_releve = $date_concil;
 		$resconcil = $obj->update_conciliation($user, 0, 1);
@@ -166,9 +173,6 @@ try {
 		}
 
 		$reconcileSuccess++;
-		if (!empty($obj->fk_account)) {
-			$reconciledAccountIds[(int) $obj->fk_account] = (int) $obj->fk_account;
-		}
 		dol_syslog('CAMT053: Reconciled bank line rowid=' . $bankLineId . ' num_releve=' . $date_concil . ' fk_account=' . $obj->fk_account, LOG_DEBUG);
 
 		if (empty($obj->datev)) {
@@ -222,12 +226,12 @@ try {
 	}
 
 	// The upload form exposes no account selector, so bank_account_id is empty here.
-	// Derive the real account id from the reconciled lines so the statement file is archived
+	// Derive the real account id from the linked lines so the statement file is archived
 	// under bank/<id>/statement/<num>/ and shown in the bank statement of the correct account.
-	if (empty($bank_account_id) && !empty($reconciledAccountIds)) {
-		$bank_account_id = reset($reconciledAccountIds);
-		if (count($reconciledAccountIds) > 1) {
-			dol_syslog('CAMT053: Reconciled lines span multiple accounts (' . implode(',', $reconciledAccountIds) . '), statement file archived under account ' . $bank_account_id . ' only', LOG_WARNING);
+	if (empty($bank_account_id) && !empty($linkedAccountIds)) {
+		$bank_account_id = reset($linkedAccountIds);
+		if (count($linkedAccountIds) > 1) {
+			dol_syslog('CAMT053: Linked lines span multiple accounts (' . implode(',', $linkedAccountIds) . '), statement file archived under account ' . $bank_account_id . ' only', LOG_WARNING);
 		}
 	}
 
@@ -236,7 +240,12 @@ try {
 	// Indexing before the move (the previous behaviour) could leave an orphan ecm_files row pointing
 	// to a file that is not on disk: the statement page (which lists from the filesystem) shows nothing,
 	// yet Dolibarr reports the file "already exists" when trying to attach it manually.
-	if (!empty($upload_file) && file_exists($upload_file)) {
+	if (!empty($upload_file) && file_exists($upload_file) && (int) $bank_account_id <= 0) {
+		// No account could be determined (e.g. no linked entries submitted): do not archive under
+		// account 0. Keep the temporary upload and warn so the statement file is not lost silently.
+		dol_syslog('CAMT053: Statement file not archived, no bank account could be determined (upload_file=' . $upload_file . ')', LOG_ERR);
+		setEventMessages($langs->trans('StatementFileNotArchived'), null, 'warnings');
+	} elseif (!empty($upload_file) && file_exists($upload_file)) {
 		$id = (int) $bank_account_id;
 		$numref = $date_concil;
 

--- a/confirm.php
+++ b/confirm.php
@@ -123,6 +123,20 @@ print '</tr>';
 $bank_account = new Account($db);
 $reconciler = new BankEntryReconciler($db, $user);
 
+// Counters and errors to give visible feedback instead of failing silently
+$reconcileSuccess = 0;
+$reconcileErrors = array();
+// Real bank account id(s) of the reconciled lines (the upload form has no account selector,
+// so bank_account_id is empty: we must derive the account from the reconciled lines)
+$reconciledAccountIds = array();
+
+// An empty statement reference makes update_conciliation() fail when BANK_STATEMENT_REGEX_RULE is set
+if (empty($date_concil)) {
+	dol_syslog('CAMT053: Empty statement reference (num_releve) computed from date_end=' . $date_end . ' - reconciliation may fail if BANK_STATEMENT_REGEX_RULE is set', LOG_WARNING);
+}
+
+dol_syslog('CAMT053: Starting reconciliation of ' . count($linked) . ' linked entry(ies), num_releve=' . $date_concil, LOG_DEBUG);
+
 try {
 	// Process each linked entry
 	foreach ($linked as $key => $link) {
@@ -135,12 +149,27 @@ try {
 		$result = $obj->fetch($bankLineId);
 
 		if ($result <= 0) {
+			dol_syslog('CAMT053: Bank line not found for reconciliation, rowid=' . $bankLineId, LOG_WARNING);
+			$reconcileErrors[] = $langs->trans('ReconciliationFailed') . ' #' . $bankLineId;
 			continue;
 		}
 
 		// Reconcile the entry
 		$obj->num_releve = $date_concil;
-		$obj->update_conciliation($user, 0, 1);
+		$resconcil = $obj->update_conciliation($user, 0, 1);
+
+		if ($resconcil <= 0) {
+			$errmsg = !empty($obj->error) ? $obj->error : (!empty($obj->errors) ? implode(', ', $obj->errors) : 'Unknown error');
+			dol_syslog('CAMT053: Failed to reconcile bank line rowid=' . $bankLineId . ' num_releve=' . $date_concil . ' - ' . $errmsg, LOG_ERR);
+			$reconcileErrors[] = $langs->trans('ReconciliationFailed') . ' #' . $bankLineId . ': ' . $errmsg;
+			continue;
+		}
+
+		$reconcileSuccess++;
+		if (!empty($obj->fk_account)) {
+			$reconciledAccountIds[(int) $obj->fk_account] = (int) $obj->fk_account;
+		}
+		dol_syslog('CAMT053: Reconciled bank line rowid=' . $bankLineId . ' num_releve=' . $date_concil . ' fk_account=' . $obj->fk_account, LOG_DEBUG);
 
 		if (empty($obj->datev)) {
 			continue;
@@ -185,80 +214,62 @@ try {
 		print '</tr>';
 	}
 
-	// Move uploaded file to document storage
+	dol_syslog('CAMT053: Reconciliation done, success=' . $reconcileSuccess . ', errors=' . count($reconcileErrors), LOG_INFO);
+
+	// Surface reconciliation errors instead of failing silently
+	if (!empty($reconcileErrors)) {
+		setEventMessages(null, $reconcileErrors, 'errors');
+	}
+
+	// The upload form exposes no account selector, so bank_account_id is empty here.
+	// Derive the real account id from the reconciled lines so the statement file is archived
+	// under bank/<id>/statement/<num>/ and shown in the bank statement of the correct account.
+	if (empty($bank_account_id) && !empty($reconciledAccountIds)) {
+		$bank_account_id = reset($reconciledAccountIds);
+		if (count($reconciledAccountIds) > 1) {
+			dol_syslog('CAMT053: Reconciled lines span multiple accounts (' . implode(',', $reconciledAccountIds) . '), statement file archived under account ' . $bank_account_id . ' only', LOG_WARNING);
+		}
+	}
+
+	// Move the uploaded file to the bank statement document storage, then index it.
+	// IMPORTANT: move the physical file FIRST and index it in the database (ecm_files) ONLY afterwards.
+	// Indexing before the move (the previous behaviour) could leave an orphan ecm_files row pointing
+	// to a file that is not on disk: the statement page (which lists from the filesystem) shows nothing,
+	// yet Dolibarr reports the file "already exists" when trying to attach it manually.
 	if (!empty($upload_file) && file_exists($upload_file)) {
-		$id = $bank_account_id;
+		$id = (int) $bank_account_id;
 		$numref = $date_concil;
-		$modulepart = 'bank';
-		$permissiontoadd = $user->hasRight('banque', 'modifier');
-		$permtoedit = $user->hasRight('banque', 'modifier');
-		$param = '&id=' . $id . '&num=' . urlencode($numref);
-		$moreparam = '&num=' . urlencode($numref);
-		$relativepathwithnofile = $id . "/statement/" . dol_sanitizeFileName($numref) . "/";
+
 		$object = new Account($db);
 		$object->fetch($id);
 
-		// Get filename from upload path
 		$file = basename($upload_file);
-		$dir = 'bank/' . ((int) $id) . '/statement/' . dol_sanitizeFileName($numref);
-
-		include_once DOL_DOCUMENT_ROOT . '/ecm/class/ecmfiles.class.php';
-		$ecmfile = new EcmFiles($db);
 		$sanitizedFilename = dol_sanitizeFileName($file);
-		$relativepath = $dir . '/' . $sanitizedFilename;
 
-		// Check if ECM entry already exists for this file
-		$existingEcm = $ecmfile->fetch(0, '', $relativepath);
+		// Same directory the bank statement page reads (see account_statement_prepare_head()
+		// in core/lib/bank.lib.php and compta/bank/account_statement_document.php)
+		$targetDir = $conf->bank->dir_output . '/' . $id . '/statement/' . dol_sanitizeFileName($numref);
+		$targetFile = $targetDir . '/' . $sanitizedFilename;
 
-		if ($existingEcm <= 0) {
-			// Entry does not exist, create it
-			$ecmfile->filepath = $dir;
-			$ecmfile->filename = $sanitizedFilename;
-			$ecmfile->label = md5_file(dol_osencode($upload_file)); // MD5 of file content
-			$ecmfile->fullpath_orig = $file;
-			$ecmfile->gen_or_uploaded = 'uploaded';
-			$ecmfile->description = '';
-			$ecmfile->keywords = '';
+		dol_syslog('CAMT053: Archiving statement file ' . $upload_file . ' to ' . $targetFile, LOG_DEBUG);
 
-			if (is_object($object) && $object->id > 0) {
-				$ecmfile->src_object_id = $object->id;
-				if (isset($object->table_element)) {
-					$ecmfile->src_object_type = $object->table_element;
-				} else {
-					dol_syslog('Error: object ' . get_class($object) . ' has no table_element attribute.');
-				}
-				if (isset($object->src_object_description)) {
-					$ecmfile->description = $object->src_object_description;
-				}
-				if (isset($object->src_object_keywords)) {
-					$ecmfile->keywords = $object->src_object_keywords;
-				}
-			}
-
-			require_once DOL_DOCUMENT_ROOT . '/core/lib/security2.lib.php';
-			$ecmfile->share = getRandomPassword(true);
-			$result = $ecmfile->create($user);
-			if ($result < 0) {
-				dol_syslog('CAMT053: Error creating ECM file entry - ' . $ecmfile->error, LOG_ERR);
-			}
-		} else {
-			dol_syslog('CAMT053: ECM file entry already exists for ' . $relativepath, LOG_DEBUG);
-		}
-
-		// Create target directory using Dolibarr function (secure permissions)
-		$targetDir = DOL_DATA_ROOT . '/' . $dir;
 		if (!is_dir($targetDir)) {
 			dol_mkdir($targetDir);
 		}
 
-		// Move file to target directory (only if it doesn't already exist)
-		$targetFile = $targetDir . '/' . $sanitizedFilename;
 		if (file_exists($targetFile)) {
-			// File already exists, remove the uploaded temporary file
+			// Physical file already in place: drop the temporary upload, keep the existing one
 			@unlink($upload_file);
-			dol_syslog('CAMT053: File already exists at ' . $targetFile . ', skipping move', LOG_DEBUG);
-		} elseif (!rename($upload_file, $targetFile)) {
-			dol_syslog('CAMT053: Error moving file to ' . $targetFile, LOG_ERR);
+			dol_syslog('CAMT053: Statement file already present at ' . $targetFile . ', skipping move', LOG_DEBUG);
+		} elseif (rename($upload_file, $targetFile)) {
+			dol_syslog('CAMT053: Statement file archived to ' . $targetFile, LOG_DEBUG);
+			// Index in database only once the file physically exists, keeping ecm_files in sync
+			$resindex = addFileIntoDatabaseIndex($targetDir, $sanitizedFilename, $file, 'uploaded', 1, $object);
+			if ($resindex < 0) {
+				dol_syslog('CAMT053: File archived but database indexing failed for ' . $targetFile, LOG_WARNING);
+			}
+		} else {
+			dol_syslog('CAMT053: Error moving statement file to ' . $targetFile, LOG_ERR);
 		}
 	}
 
@@ -285,8 +296,9 @@ try {
 
 	print '</div>';
 	print '</div>';
-} catch (Exception $e) {
-	dol_syslog('CAMT053: Error during confirmation - ' . $e->getMessage(), LOG_ERR);
+} catch (Throwable $e) {
+	// Catch both Exception and Error/TypeError (PHP 8) to avoid a blank page
+	dol_syslog('CAMT053: Error during confirmation - ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine(), LOG_ERR);
 	setEventMessages($langs->trans('ErrorProcessingFile') . ': ' . $e->getMessage(), null, 'errors');
 }
 

--- a/langs/en_US/camt053readerandlink.lang
+++ b/langs/en_US/camt053readerandlink.lang
@@ -42,3 +42,4 @@ NoEntriesToReconcile = No entries found to reconcile
 BasedOnPreviousMonthIfNotFilled = Based on the previous month of the file extraction date if not filled
 ErrorProcessingFile = Error while processing the file
 ReconciliationFailed = Reconciliation failed for bank line
+StatementFileNotArchived = The statement file could not be archived because no bank account could be determined

--- a/langs/en_US/camt053readerandlink.lang
+++ b/langs/en_US/camt053readerandlink.lang
@@ -40,3 +40,5 @@ ViewBankStatement = View bank statement
 AllEntriesReconciled = All entries are already reconciled
 NoEntriesToReconcile = No entries found to reconcile
 BasedOnPreviousMonthIfNotFilled = Based on the previous month of the file extraction date if not filled
+ErrorProcessingFile = Error while processing the file
+ReconciliationFailed = Reconciliation failed for bank line

--- a/langs/en_US/camt053readerandlink.lang
+++ b/langs/en_US/camt053readerandlink.lang
@@ -38,4 +38,5 @@ ConcilationsConfirmed = Conciliations confirmed
 CheckNewConciliations = Check new conciliations
 ViewBankStatement = View bank statement
 AllEntriesReconciled = All entries are already reconciled
+NoEntriesToReconcile = No entries found to reconcile
 BasedOnPreviousMonthIfNotFilled = Based on the previous month of the file extraction date if not filled

--- a/langs/fr_FR/camt053readerandlink.lang
+++ b/langs/fr_FR/camt053readerandlink.lang
@@ -40,4 +40,5 @@ ConcilationsConfirmed = Rapprochements confirmés
 CheckNewConciliations = Vérifier les nouveaux rapprochements
 ViewBankStatement = Voir le relevé bancaire
 AllEntriesReconciled = Toutes les écritures sont déjà rapprochées
+NoEntriesToReconcile = Aucune écriture trouvée à rapprocher
 BasedOnPreviousMonthIfNotFilled = Basé sur le mois précédent de la date d'extraction du fichier si non rempli

--- a/langs/fr_FR/camt053readerandlink.lang
+++ b/langs/fr_FR/camt053readerandlink.lang
@@ -44,3 +44,4 @@ NoEntriesToReconcile = Aucune écriture trouvée à rapprocher
 BasedOnPreviousMonthIfNotFilled = Basé sur le mois précédent de la date d'extraction du fichier si non rempli
 ErrorProcessingFile = Erreur lors du traitement du fichier
 ReconciliationFailed = Échec du rapprochement pour la ligne bancaire
+StatementFileNotArchived = Le fichier de relevé n'a pas pu être archivé car aucun compte bancaire n'a pu être déterminé

--- a/langs/fr_FR/camt053readerandlink.lang
+++ b/langs/fr_FR/camt053readerandlink.lang
@@ -42,3 +42,5 @@ ViewBankStatement = Voir le relevé bancaire
 AllEntriesReconciled = Toutes les écritures sont déjà rapprochées
 NoEntriesToReconcile = Aucune écriture trouvée à rapprocher
 BasedOnPreviousMonthIfNotFilled = Basé sur le mois précédent de la date d'extraction du fichier si non rempli
+ErrorProcessingFile = Erreur lors du traitement du fichier
+ReconciliationFailed = Échec du rapprochement pour la ligne bancaire

--- a/submit.php
+++ b/submit.php
@@ -223,11 +223,8 @@ if ($action == 'upload') {
 			$redirectUrl = DOL_URL_ROOT . '/compta/bank/releve.php?account=' . ((int) $firstAccountId) . '&num=' . urlencode($date_concil);
 			setEventMessages($langs->trans('AllEntriesReconciled'), null, 'mesgs');
 		}
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		dol_syslog('CAMT053: Error processing file - ' . $e->getMessage(), LOG_ERR);
-		$processError = $e->getMessage();
-	} catch (TypeError $e) {
-		dol_syslog('CAMT053: Type error processing file - ' . $e->getMessage(), LOG_ERR);
 		$processError = $e->getMessage();
 	}
 }

--- a/submit.php
+++ b/submit.php
@@ -131,6 +131,9 @@ if ($action == 'upload') {
 		if (!empty($file_json)) {
 			// Parse from previously uploaded JSON
 			$structure = json_decode(urldecode($file_json), true);
+			if (!is_array($structure)) {
+				throw new Exception('Error decoding JSON structure');
+			}
 			if (!$fileProcessor->parseStructure($structure)) {
 				throw new Exception($fileProcessor->getError() ?? 'Error parsing JSON structure');
 			}
@@ -223,6 +226,9 @@ if ($action == 'upload') {
 	} catch (Exception $e) {
 		dol_syslog('CAMT053: Error processing file - ' . $e->getMessage(), LOG_ERR);
 		$processError = $e->getMessage();
+	} catch (TypeError $e) {
+		dol_syslog('CAMT053: Type error processing file - ' . $e->getMessage(), LOG_ERR);
+		$processError = $e->getMessage();
 	}
 }
 
@@ -256,6 +262,9 @@ if (!empty($processError)) {
 }
 
 // Display results if we have data
+if (empty($banks) && empty($processError)) {
+	print '<div class="opacitymedium">'.$langs->trans('NoEntriesToReconcile').'</div>';
+}
 if (!empty($banks)) {
 	print '<form id="form" name="form" action="'.dol_buildpath('/custom/camt053readerandlink/confirm.php', 1).'" method="post">';
 


### PR DESCRIPTION
## Summary

Fixes several issues in the CAMT.053 reconciliation flow, reported when confirming reconciliations and when looking for the imported file in the bank statement.

## Changes

### Empty page when nothing to reconcile (ecbd047)
- Guard against invalid JSON before `parseStructure()` and catch `TypeError`.
- Show a clear message instead of a blank page when there is nothing to reconcile.

### Statement file archived under the wrong account (4aff32a)
- The upload form has no account selector, so `bank_account_id` was always `0` and the file was stored under `bank/0/statement/<num>/`, invisible in the real account's statement.
- The real account id is now derived from the `fk_account` of the reconciled bank lines.
- The physical path now uses `$conf->bank->dir_output` (matches where the statement page reads files, multicompany-safe).

### "File already exists but does not appear"
- The file was indexed in `ecm_files` *before* (and independently of) the physical move, which could leave an orphan index row: the statement page (filesystem listing) showed nothing, yet Dolibarr reported the file already existed on manual attach.
- The file is now moved first, then indexed via the canonical `addFileIntoDatabaseIndex()` helper, keeping the database and filesystem in sync.

### Defensive hardening
- `update_conciliation()` return value is now checked and surfaced instead of failing silently.
- Reconciliation steps are logged (`CAMT053:` prefix) and the confirmation block catches `Throwable` to avoid blank pages on PHP 8 errors.
- Added missing translation keys (`ErrorProcessingFile`, `ReconciliationFailed`) in en_US and fr_FR.