### PR TITLE
fix: scope bank account IBAN lookup to the current entity

### DIFF
--- a/class/Camt053FileProcessor.class.php
+++ b/class/Camt053FileProcessor.class.php
@@ -417,9 +417,12 @@ class Camt053FileProcessor
 		$ibanNoSpace = str_replace(' ', '', $iban);
 		$ibanWithSpace = $this->formatIban($iban);
 
+		// Restrict to accounts visible in the current entity: an IBAN belonging to
+		// another entity's account must not be treated as a reconcilable account.
 		$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "bank_account ";
-		$sql .= "WHERE iban_prefix = '" . $this->db->escape($ibanWithSpace) . "' ";
-		$sql .= "OR iban_prefix = '" . $this->db->escape($ibanNoSpace) . "'";
+		$sql .= "WHERE (iban_prefix = '" . $this->db->escape($ibanWithSpace) . "' ";
+		$sql .= "OR iban_prefix = '" . $this->db->escape($ibanNoSpace) . "') ";
+		$sql .= "AND entity IN (" . getEntity('bank_account') . ")";
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/class/DatabaseBankStatementLoader.class.php
+++ b/class/DatabaseBankStatementLoader.class.php
@@ -79,16 +79,19 @@ class DatabaseBankStatementLoader
 			return array();
 		}
 
-		// Build secure SQL query
-		$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "bank ";
-		$sql .= "WHERE datev >= DATE('" . $this->db->escape($startDateStr) . "') ";
-		$sql .= "AND datev <= DATE('" . $this->db->escape($endDateStr) . "') ";
+		// Build secure SQL query. Join bank_account to keep entries scoped to the
+		// current entity: a bank line from another entity must never be matched.
+		$sql = "SELECT b.rowid FROM " . MAIN_DB_PREFIX . "bank AS b ";
+		$sql .= "INNER JOIN " . MAIN_DB_PREFIX . "bank_account AS ba ON ba.rowid = b.fk_account ";
+		$sql .= "WHERE b.datev >= DATE('" . $this->db->escape($startDateStr) . "') ";
+		$sql .= "AND b.datev <= DATE('" . $this->db->escape($endDateStr) . "') ";
+		$sql .= "AND ba.entity IN (" . getEntity('bank_account') . ") ";
 
 		if ($accountId !== null) {
-			$sql .= "AND fk_account = " . ((int) $accountId) . " ";
+			$sql .= "AND b.fk_account = " . ((int) $accountId) . " ";
 		}
 
-		$sql .= "ORDER BY datev ASC";
+		$sql .= "ORDER BY b.datev ASC";
 
 		$resql = $this->db->query($sql);
 		if (!$resql) {
@@ -213,6 +216,7 @@ class DatabaseBankStatementLoader
 	{
 		$sql = "SELECT rowid, iban_prefix FROM " . MAIN_DB_PREFIX . "bank_account ";
 		$sql .= "WHERE rowid = " . ((int) $bankId);
+		$sql .= " AND entity IN (" . getEntity('bank_account') . ")";
 
 		$resql = $this->db->query($sql);
 		if (!$resql) {
@@ -244,8 +248,9 @@ class DatabaseBankStatementLoader
 		$ibanWithSpace = $this->formatIban($iban);
 
 		$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "bank_account ";
-		$sql .= "WHERE iban_prefix = '" . $this->db->escape($ibanWithSpace) . "' ";
-		$sql .= "OR iban_prefix = '" . $this->db->escape($ibanNoSpace) . "'";
+		$sql .= "WHERE (iban_prefix = '" . $this->db->escape($ibanWithSpace) . "' ";
+		$sql .= "OR iban_prefix = '" . $this->db->escape($ibanNoSpace) . "') ";
+		$sql .= "AND entity IN (" . getEntity('bank_account') . ")";
 
 		$resql = $this->db->query($sql);
 		if ($resql) {

--- a/langs/en_US/camt053readerandlink.lang
+++ b/langs/en_US/camt053readerandlink.lang
@@ -39,6 +39,7 @@ CheckNewConciliations = Check new conciliations
 ViewBankStatement = View bank statement
 AllEntriesReconciled = All entries are already reconciled
 NoEntriesToReconcile = No entries found to reconcile
+Camt053IbanNotInCurrentEntity = The bank account with IBAN %s does not exist in the current entity. Its entries were ignored. Switch to the entity that owns this account before importing.
 BasedOnPreviousMonthIfNotFilled = Based on the previous month of the file extraction date if not filled
 ErrorProcessingFile = Error while processing the file
 ReconciliationFailed = Reconciliation failed for bank line

--- a/langs/fr_FR/camt053readerandlink.lang
+++ b/langs/fr_FR/camt053readerandlink.lang
@@ -41,6 +41,7 @@ CheckNewConciliations = Vérifier les nouveaux rapprochements
 ViewBankStatement = Voir le relevé bancaire
 AllEntriesReconciled = Toutes les écritures sont déjà rapprochées
 NoEntriesToReconcile = Aucune écriture trouvée à rapprocher
+Camt053IbanNotInCurrentEntity = Le compte bancaire avec l'IBAN %s n'existe pas dans l'entité courante. Ses écritures ont été ignorées. Basculez vers l'entité propriétaire de ce compte avant d'importer.
 BasedOnPreviousMonthIfNotFilled = Basé sur le mois précédent de la date d'extraction du fichier si non rempli
 ErrorProcessingFile = Erreur lors du traitement du fichier
 ReconciliationFailed = Échec du rapprochement pour la ligne bancaire

--- a/submit.php
+++ b/submit.php
@@ -263,6 +263,15 @@ if ($action == 'upload') {
 			throw new Exception($dbLoader->getError());
 		}
 
+		// Warn about statements whose IBAN matches no bank account in the current
+		// entity: their entries are dropped (getStatementsByAccountId keeps only
+		// resolved accounts), so reconciliation must not silently ignore them.
+		foreach ($fileProcessor->getStatements() as $stmt) {
+			if ($stmt->getAccountId() === null && $stmt->getEntryCount() > 0) {
+				setEventMessages($langs->trans('Camt053IbanNotInCurrentEntity', $stmt->getIban()), null, 'warnings');
+			}
+		}
+
 		// Get file statements indexed by account ID
 		$fileStatements = $fileProcessor->getStatementsByAccountId();
 


### PR DESCRIPTION
## Problem
Importing a CAMT.053 file whose IBAN belongs to a bank account in **another entity** still resolved to that account, so the user could reconcile entries against an account they should not even see.

## Cause
The IBAN → bank account lookups (`Camt053FileProcessor::findAccountByIban`, `DatabaseBankStatementLoader::getAccountIdByIban` / `getDbBank`) and the database bank-line load were not filtered by entity.

## Fix
- Scope every IBAN / account lookup and the DB bank-line query to accounts visible in the current entity via `entity IN (getEntity('bank_account'))`.
- When a statement's IBAN resolves to no account in the current entity, show a clear warning (new `Camt053IbanNotInCurrentEntity` string, EN/FR) instead of silently dropping its entries.

## Test
No local PHP runtime available; verified logic by review. Existing PHPUnit tests are unaffected (they run without `MAIN_DB_PREFIX`, so `getEntity` is never reached).