### PR TITLE
fix: show related invoice in the multi-match reconciliation dropdown

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -413,7 +413,14 @@ if (!empty($banks)) {
 					$n = dol_escape_htmltag($dbEntry['name']);
 					$a = number_format($dbEntry['amount'], 2);
 					$d = dol_escape_htmltag($dbEntry['value_date']);
-					$array[$id] = '(' . $id . ') ' . $n . '<br />' . $a . '<br />' . $d;
+					// Prepend the related document (invoice ref + third party) so
+					// same-amount candidates can be told apart in the dropdown.
+					$doc = '';
+					$relation = $relationLookup->getRelation((int) $id);
+					if ($relation !== null && !empty($relation['ref'])) {
+						$doc = dol_escape_htmltag(trim($relation['ref'] . ' - ' . $relation['label'])) . '<br />';
+					}
+					$array[$id] = '(' . $id . ') ' . $doc . $n . '<br />' . $a . '<br />' . $d;
 				}
 				print $form->selectMassAction('', $array, 1, 'linked_' . dol_escape_htmltag($ntry_hash));
 				print '</td>';


### PR DESCRIPTION
## Problem
When several Dolibarr bank transactions of the same amount and date match a single CAMT.053 entry, the selection dropdown listed only the label, amount and date. With multiple candidate payments it was impossible to tell which invoice each one belonged to.

## Fix
For each candidate bank line, look up its related document via `BankRelationshipLookup::getRelation` and prepend the invoice reference and third party to the dropdown option, so the correct payment can be identified.

## Test
No local PHP runtime available; verified logic by review.